### PR TITLE
update to escape all escape sequences that are not automatically escaped

### DIFF
--- a/ParserTests/QueryTest.cs
+++ b/ParserTests/QueryTest.cs
@@ -4,7 +4,6 @@ using PrismaDB.QueryAST.DDL;
 using PrismaDB.QueryAST.DML;
 using PrismaDB.QueryParser.MySQL;
 using Xunit;
-using System.Diagnostics;
 
 namespace ParserTests
 {
@@ -593,22 +592,21 @@ namespace ParserTests
         public void Parse_Escaped()
         {
             // Setup 1
-            
             // % and _ are automatically escaped outside of pattern-matching context; meaning that any \ before a % and _ is treated literally
             var test1 = "INSERT INTO TestTable (a, b, c, d, e, f, g, h, i, j, k, l) VALUES (" +
-            "'ascii_null_\\0 foo\\0foo'," +
-            "'single_quote_\\' '''," +
-            "'double_quote1_\" \\\"'," +
-            "\"double_quote2_\\\" \"\"\"," +
-            "'backspace_\\b'," +
-            "'newline_\\n'," +
-            "'carriage_return_\\r',"+
-            "'tab_\\t'," + 
-            "'ascii_26_\\Z'," +
-            "'backslash_\\\\'," + 
-            "'percentage_% \\%'," + 
-            "'underscore_ \\_'" + 
-            ")";
+                        "'ascii_null_\\0 foo\\0foo'," +
+                        "'single_quote_\\' '''," +
+                        "'double_quote1_\" \\\"'," +
+                        "\"double_quote2_\\\" \"\"\"," +
+                        "'backspace_\\b'," +
+                        "'newline_\\n'," +
+                        "'carriage_return_\\r'," +
+                        "'tab_\\t'," +
+                        "'ascii_26_\\Z'," +
+                        "'backslash_\\\\'," +
+                        "'percentage_% \\%'," +
+                        "'underscore_ \\_'" +
+                        ")";
 
             // Act 1
             var result1 = MySqlQueryParser.ParseToAst(test1);
@@ -617,47 +615,47 @@ namespace ParserTests
             Assert.Equal("ascii_null_\0 foo\0foo", ((StringConstant)((InsertQuery)result1[0]).Values[0][0]).strvalue);
             Assert.Equal("single_quote_' '", ((StringConstant)((InsertQuery)result1[0]).Values[0][1]).strvalue);
             Assert.Equal("double_quote1_\" \"", ((StringConstant)((InsertQuery)result1[0]).Values[0][2]).strvalue); // sql: \"
-            Assert.Equal("double_quote2_\" \"", ((StringConstant)((InsertQuery)result1[0]).Values[0][3]).strvalue); 
-            Assert.Equal("backspace_\b", ((StringConstant)((InsertQuery)result1[0]).Values[0][4]).strvalue); 
-            Assert.Equal("newline_\n", ((StringConstant)((InsertQuery)result1[0]).Values[0][5]).strvalue); 
+            Assert.Equal("double_quote2_\" \"", ((StringConstant)((InsertQuery)result1[0]).Values[0][3]).strvalue);
+            Assert.Equal("backspace_\b", ((StringConstant)((InsertQuery)result1[0]).Values[0][4]).strvalue);
+            Assert.Equal("newline_\n", ((StringConstant)((InsertQuery)result1[0]).Values[0][5]).strvalue);
             Assert.Equal("carriage_return_\r", ((StringConstant)((InsertQuery)result1[0]).Values[0][6]).strvalue);
             Assert.Equal("tab_\t", ((StringConstant)((InsertQuery)result1[0]).Values[0][7]).strvalue);
-            Assert.Equal("ascii_26_" + (char)26, ((StringConstant)((InsertQuery)result1[0]).Values[0][8]).strvalue);
+            Assert.Equal("ascii_26_\x1A", ((StringConstant)((InsertQuery)result1[0]).Values[0][8]).strvalue);
             Assert.Equal("backslash_\\", ((StringConstant)((InsertQuery)result1[0]).Values[0][9]).strvalue);
             Assert.Equal("percentage_% \\%", ((StringConstant)((InsertQuery)result1[0]).Values[0][10]).strvalue);
             Assert.Equal("underscore_ \\_", ((StringConstant)((InsertQuery)result1[0]).Values[0][11]).strvalue);
 
             // Setup 2
             var test2 = "INSERT INTO TT1 (a, b, c, d, e) VALUES " +
-                       "('I\\'m', '\\\"escaped\"', \"\"\"and\", '''me ''too')";
+                        "('I\\'m', '\\\"escaped\"', \"\"\"and\", '''me ''too')";
             // Act 2
             var result2 = MySqlQueryParser.ParseToAst(test2);
 
             // Assert 2
-            Assert.Equal("I'm", ((StringConstant)((InsertQuery)result2[0]).Values[0][0]).strvalue); 
-            Assert.Equal("\"escaped\"", ((StringConstant)((InsertQuery)result2[0]).Values[0][1]).strvalue); 
-            Assert.Equal("\"and", ((StringConstant)((InsertQuery)result2[0]).Values[0][2]).strvalue); 
+            Assert.Equal("I'm", ((StringConstant)((InsertQuery)result2[0]).Values[0][0]).strvalue);
+            Assert.Equal("\"escaped\"", ((StringConstant)((InsertQuery)result2[0]).Values[0][1]).strvalue);
+            Assert.Equal("\"and", ((StringConstant)((InsertQuery)result2[0]).Values[0][2]).strvalue);
             Assert.Equal("'me 'too", ((StringConstant)((InsertQuery)result2[0]).Values[0][3]).strvalue);
 
             // Setup 3
             // use wxy as most unambigious character range without escape character usages. the rest are used as SQL, C# or ASCII escape chars
             var test3 = "INSERT INTO TestTable(a,b,c,d) VALUES (" +
-                "'mixed_\\b\\0\\t\\r\\n\\\n \\\\w \\x \\y',"+
-                "'order_of_replacement_1_\\ \\n \\\n \\\\n \\\\\n \\\\\\n \\\\\\\n \\\\\\\\n'," +
-                "'order_of_replacement_2_\\\r \\\t \\\\\\n \\\\\\\\\\\\\\\\\\b \\\\n\\\\r'," +                
-                "'all_single_enclosed_\\0 \\\\\\\\ \\' '' \\t \\\" \\\\Z \\Z \\r\\n\\b \\\'\'\''," +
-                "\"all_double_enclosed_\\0 \\\\\\\\ \\' \\t \\\\\"\" \\\\Z \\Z \"\"\"\" \\r\\n\\b \\\"\"\"\"" +
-                ")";
-            // Act 3
+                        "'mixed_\\b\\0\\t\\r\\n\\\n \\\\w \\x \\y'," +
+                        "'order_of_replacement_1_\\ \\n \\\n \\\\n \\\\\n \\\\\\n \\\\\\\n \\\\\\\\n'," +
+                        "'order_of_replacement_2_\\\r \\\t \\\\\\n \\\\\\\\\\\\\\\\\\b \\\\n\\\\r'," +
+                        "'all_single_enclosed_\\0 \\\\\\\\ \\' '' \\t \\\" \\\\Z \\Z \\r\\n\\b \\\'\'\''," +
+                        "\"all_double_enclosed_\\0 \\\\\\\\ \\' \\t \\\\\"\" \\\\Z \\Z \"\"\"\" \\r\\n\\b \\\"\"\"\"" +
+                        ")";
 
+            // Act 3
             var result3 = MySqlQueryParser.ParseToAst(test3);
 
             // Assert 3
             Assert.Equal("mixed_\b\0\t\r\n\n \\w x y", ((StringConstant)((InsertQuery)result3[0]).Values[0][0]).strvalue);
             Assert.Equal("order_of_replacement_1_ \n \n \\n \\\n \\\n \\\n \\\\n", ((StringConstant)((InsertQuery)result3[0]).Values[0][1]).strvalue);
             Assert.Equal("order_of_replacement_2_\r \t \\\n \\\\\\\\\b \\n\\r", ((StringConstant)((InsertQuery)result3[0]).Values[0][2]).strvalue);
-            Assert.Equal("all_single_enclosed_\0 \\\\ \' \' \t \" \\Z " + (char)26 + " \r\n\b \'\'" , ((StringConstant)((InsertQuery)result3[0]).Values[0][3]).strvalue);
-            Assert.Equal("all_double_enclosed_\0 \\\\ \' \t \\\" \\Z " + (char)26 + " \"\" \r\n\b \"\"", ((StringConstant)((InsertQuery)result3[0]).Values[0][4]).strvalue);
+            Assert.Equal("all_single_enclosed_\0 \\\\ \' \' \t \" \\Z \x1A \r\n\b \'\'", ((StringConstant)((InsertQuery)result3[0]).Values[0][3]).strvalue);
+            Assert.Equal("all_double_enclosed_\0 \\\\ \' \t \\\" \\Z \x1A \"\" \r\n\b \"\"", ((StringConstant)((InsertQuery)result3[0]).Values[0][4]).strvalue);
 
         }
 
@@ -752,4 +750,3 @@ namespace ParserTests
         }
     }
 }
- 

--- a/ParserTests/QueryTest.cs
+++ b/ParserTests/QueryTest.cs
@@ -591,18 +591,56 @@ namespace ParserTests
         [Fact(DisplayName = "Parse escaped")]
         public void Parse_Escaped()
         {
-            // Setup
-            var test = "INSERT INTO TT1 (a, b, c, d, e) VALUES " +
+            // Setup 1
+            
+            // % and _ are automatically escaped outside of pattern-matching context, but tested for completeness
+            var test1 = "INSERT INTO TestTable (a, b, c, d, e, f, g, h, i, j, k, l) VALUES (" +
+            "'ascii_null_\\0 foo\\0foo'," +
+            "'single_quote_\\' '''," +
+            "'double_quote1_\" \\\"'," +
+            "\"double_quote2_\\\" \"\"\"," +
+            "'backspace_\\b'," +
+            "'newline_\\n'," +
+            "'carriage_return_\\r',"+
+            "'tab_\\t'," + 
+            "'ascii_26_\\Z'," +
+            "'backslash_\\\\'," + 
+            "'percentage_% \\%'," + 
+            "'underscore_\\_'" + 
+            ")";
+
+
+            // Act 1
+            var result1 = MySqlQueryParser.ParseToAst(test1);
+
+
+            // Assert 1
+            Assert.Equal("ascii_null_\0 foo\0foo", ((StringConstant)((InsertQuery)result1[0]).Values[0][0]).strvalue);
+            Assert.Equal("single_quote_' '", ((StringConstant)((InsertQuery)result1[0]).Values[0][1]).strvalue);
+            Assert.Equal("double_quote1_\" \\\"", ((StringConstant)((InsertQuery)result1[0]).Values[0][2]).strvalue);
+            Assert.Equal("double_quote2_\" \"", ((StringConstant)((InsertQuery)result1[0]).Values[0][3]).strvalue); 
+            Assert.Equal("backspace_\b", ((StringConstant)((InsertQuery)result1[0]).Values[0][4]).strvalue); 
+            Assert.Equal("newline_\n", ((StringConstant)((InsertQuery)result1[0]).Values[0][5]).strvalue); 
+            Assert.Equal("carriage_return_\r", ((StringConstant)((InsertQuery)result1[0]).Values[0][6]).strvalue);
+            Assert.Equal("tab_\t", ((StringConstant)((InsertQuery)result1[0]).Values[0][7]).strvalue);
+            Assert.Equal("ascii_26_" + (char)26, ((StringConstant)((InsertQuery)result1[0]).Values[0][8]).strvalue);
+            Assert.Equal("backslash_\\", ((StringConstant)((InsertQuery)result1[0]).Values[0][9]).strvalue);
+            Assert.Equal("percentage_% \\%", ((StringConstant)((InsertQuery)result1[0]).Values[0][10]).strvalue);
+            Assert.Equal("underscore_\\_", ((StringConstant)((InsertQuery)result1[0]).Values[0][11]).strvalue);
+
+
+            // Setup 2
+            var test2 = "INSERT INTO TT1 (a, b, c, d, e) VALUES " +
                        "('I\\'m', '\\\"escaped\"', \"\"\"and\", '''me ''too')";
+            // Act 2
+            var result2 = MySqlQueryParser.ParseToAst(test2);
 
-            // Act
-            var result = MySqlQueryParser.ParseToAst(test);
+            // Assert 2
+            Assert.Equal("I'm", ((StringConstant)((InsertQuery)result2[0]).Values[0][0]).strvalue); 
+            Assert.Equal("\\\"escaped\"", ((StringConstant)((InsertQuery)result2[0]).Values[0][1]).strvalue); 
+            Assert.Equal("\"and", ((StringConstant)((InsertQuery)result2[0]).Values[0][2]).strvalue); 
+            Assert.Equal("'me 'too", ((StringConstant)((InsertQuery)result2[0]).Values[0][3]).strvalue);
 
-            // Assert
-            Assert.Equal("I'm", ((StringConstant)((InsertQuery)result[0]).Values[0][0]).strvalue);
-            Assert.Equal("\\\"escaped\"", ((StringConstant)((InsertQuery)result[0]).Values[0][1]).strvalue);
-            Assert.Equal("\"and", ((StringConstant)((InsertQuery)result[0]).Values[0][2]).strvalue);
-            Assert.Equal("'me 'too", ((StringConstant)((InsertQuery)result[0]).Values[0][3]).strvalue);
         }
 
         [Fact(DisplayName = "Parse order of operations")]

--- a/ParserTests/QueryTest.cs
+++ b/ParserTests/QueryTest.cs
@@ -4,6 +4,7 @@ using PrismaDB.QueryAST.DDL;
 using PrismaDB.QueryAST.DML;
 using PrismaDB.QueryParser.MySQL;
 using Xunit;
+using System.Diagnostics;
 
 namespace ParserTests
 {
@@ -593,7 +594,7 @@ namespace ParserTests
         {
             // Setup 1
             
-            // % and _ are automatically escaped outside of pattern-matching context, but tested for completeness
+            // % and _ are automatically escaped outside of pattern-matching context; meaning that any \ before a % and _ is treated literally
             var test1 = "INSERT INTO TestTable (a, b, c, d, e, f, g, h, i, j, k, l) VALUES (" +
             "'ascii_null_\\0 foo\\0foo'," +
             "'single_quote_\\' '''," +
@@ -606,18 +607,16 @@ namespace ParserTests
             "'ascii_26_\\Z'," +
             "'backslash_\\\\'," + 
             "'percentage_% \\%'," + 
-            "'underscore_\\_'" + 
+            "'underscore_ \\_'" + 
             ")";
-
 
             // Act 1
             var result1 = MySqlQueryParser.ParseToAst(test1);
 
-
             // Assert 1
             Assert.Equal("ascii_null_\0 foo\0foo", ((StringConstant)((InsertQuery)result1[0]).Values[0][0]).strvalue);
             Assert.Equal("single_quote_' '", ((StringConstant)((InsertQuery)result1[0]).Values[0][1]).strvalue);
-            Assert.Equal("double_quote1_\" \\\"", ((StringConstant)((InsertQuery)result1[0]).Values[0][2]).strvalue);
+            Assert.Equal("double_quote1_\" \"", ((StringConstant)((InsertQuery)result1[0]).Values[0][2]).strvalue); // sql: \"
             Assert.Equal("double_quote2_\" \"", ((StringConstant)((InsertQuery)result1[0]).Values[0][3]).strvalue); 
             Assert.Equal("backspace_\b", ((StringConstant)((InsertQuery)result1[0]).Values[0][4]).strvalue); 
             Assert.Equal("newline_\n", ((StringConstant)((InsertQuery)result1[0]).Values[0][5]).strvalue); 
@@ -626,8 +625,7 @@ namespace ParserTests
             Assert.Equal("ascii_26_" + (char)26, ((StringConstant)((InsertQuery)result1[0]).Values[0][8]).strvalue);
             Assert.Equal("backslash_\\", ((StringConstant)((InsertQuery)result1[0]).Values[0][9]).strvalue);
             Assert.Equal("percentage_% \\%", ((StringConstant)((InsertQuery)result1[0]).Values[0][10]).strvalue);
-            Assert.Equal("underscore_\\_", ((StringConstant)((InsertQuery)result1[0]).Values[0][11]).strvalue);
-
+            Assert.Equal("underscore_ \\_", ((StringConstant)((InsertQuery)result1[0]).Values[0][11]).strvalue);
 
             // Setup 2
             var test2 = "INSERT INTO TT1 (a, b, c, d, e) VALUES " +
@@ -637,9 +635,29 @@ namespace ParserTests
 
             // Assert 2
             Assert.Equal("I'm", ((StringConstant)((InsertQuery)result2[0]).Values[0][0]).strvalue); 
-            Assert.Equal("\\\"escaped\"", ((StringConstant)((InsertQuery)result2[0]).Values[0][1]).strvalue); 
+            Assert.Equal("\"escaped\"", ((StringConstant)((InsertQuery)result2[0]).Values[0][1]).strvalue); 
             Assert.Equal("\"and", ((StringConstant)((InsertQuery)result2[0]).Values[0][2]).strvalue); 
             Assert.Equal("'me 'too", ((StringConstant)((InsertQuery)result2[0]).Values[0][3]).strvalue);
+
+            // Setup 3
+            // use wxy as most unambigious character range without escape character usages. the rest are used as SQL, C# or ASCII escape chars
+            var test3 = "INSERT INTO TestTable(a,b,c,d) VALUES (" +
+                "'mixed_\\b\\0\\t\\r\\n\\\n \\\\w \\x \\y',"+
+                "'order_of_replacement_1_\\ \\n \\\n \\\\n \\\\\n \\\\\\n \\\\\\\n \\\\\\\\n'," +
+                "'order_of_replacement_2_\\\r \\\t \\\\\\n \\\\\\\\\\\\\\\\\\b \\\\n\\\\r'," +                
+                "'all_single_enclosed_\\0 \\\\\\\\ \\' '' \\t \\\" \\\\Z \\Z \\r\\n\\b \\\'\'\''," +
+                "\"all_double_enclosed_\\0 \\\\\\\\ \\' \\t \\\\\"\" \\\\Z \\Z \"\"\"\" \\r\\n\\b \\\"\"\"\"" +
+                ")";
+            // Act 3
+
+            var result3 = MySqlQueryParser.ParseToAst(test3);
+
+            // Assert 3
+            Assert.Equal("mixed_\b\0\t\r\n\n \\w x y", ((StringConstant)((InsertQuery)result3[0]).Values[0][0]).strvalue);
+            Assert.Equal("order_of_replacement_1_ \n \n \\n \\\n \\\n \\\n \\\\n", ((StringConstant)((InsertQuery)result3[0]).Values[0][1]).strvalue);
+            Assert.Equal("order_of_replacement_2_\r \t \\\n \\\\\\\\\b \\n\\r", ((StringConstant)((InsertQuery)result3[0]).Values[0][2]).strvalue);
+            Assert.Equal("all_single_enclosed_\0 \\\\ \' \' \t \" \\Z " + (char)26 + " \r\n\b \'\'" , ((StringConstant)((InsertQuery)result3[0]).Values[0][3]).strvalue);
+            Assert.Equal("all_double_enclosed_\0 \\\\ \' \t \\\" \\Z " + (char)26 + " \"\" \r\n\b \"\"", ((StringConstant)((InsertQuery)result3[0]).Values[0][4]).strvalue);
 
         }
 
@@ -734,3 +752,4 @@ namespace ParserTests
         }
     }
 }
+ 

--- a/PrismaDB-QueryParser-MySQL/Visitors/CommonVisitors.cs
+++ b/PrismaDB-QueryParser-MySQL/Visitors/CommonVisitors.cs
@@ -5,6 +5,9 @@ using PrismaDB.QueryAST.DML;
 using PrismaDB.QueryParser.MySQL.AntlrGrammer;
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Text;
+using System.Diagnostics;
 
 namespace PrismaDB.QueryParser.MySQL
 {
@@ -77,36 +80,69 @@ namespace PrismaDB.QueryParser.MySQL
 
         public override object VisitStringLiteral([NotNull] MySqlParser.StringLiteralContext context)
         {
+
             var str = context.STRING_LITERAL().GetText();
-            var c = (char)26;
+
             if (str.StartsWith("'"))
             {
                 str = str.Substring(1, str.Length - 2)
-                    .Replace("\\'", "'")
-                    .Replace("''", "'")
-                    .Replace("\\\\", "\\")
-                    .Replace("\\0", "\0")
-                    .Replace("\\b", "\b")
-                    .Replace("\\n", "\n")
-                    .Replace("\\r", "\r")
-                    .Replace("\\t", "\t")
-                    .Replace("\\Z", c.ToString());
-                return new StringConstant(str);
+                    .Replace("''", "'");
+
+                return new StringConstant(replace_common_sequences(str));
             }
+
             if (str.StartsWith("\""))
             {
                 str = str.Substring(1, str.Length - 2)
-                    .Replace("\\\"", "\"")
-                    .Replace("\"\"", "\"")
-                    .Replace("\\\\","\\")
-                    .Replace("\\0", "\0")
-                    .Replace("\\b", "\b")
-                    .Replace("\\n", "\n")
-                    .Replace("\\r", "\r")
-                    .Replace("\\t", "\t")
-                    .Replace("\\Z", c.ToString());
-                return new StringConstant(str);
+                    .Replace("\"\"", "\"");
+                return new StringConstant(replace_common_sequences(str));
             }
+
+            string replace_common_sequences(string replace)
+            {
+                var c = (char)26;
+                StringBuilder s = new StringBuilder();
+                for(int i = 0; i < replace.Length; i++)
+                {
+                    if(replace[i] == '\\' && (i <= replace.Length - 2))
+                    {
+                        switch(replace[i+1])
+                        {
+                            case '\\':
+                                s.Append("\\"); i++; break;
+                            case 'b':
+                                s.Append("\b"); i++; break;
+                            case 'n':
+                                s.Append("\n"); i++; break;
+                            case 'r':
+                                s.Append("\r"); i++; break;
+                            case 't':
+                                s.Append("\t"); i++;  break;
+                            case '0':
+                                s.Append("\0"); i++; break;
+                            case 'Z':
+                                s.Append(c); i++;  break;
+                            case '"':
+                                s.Append("\""); i++; break;
+                            case '\'':
+                                s.Append("'"); i++;  break;
+                            case '%':
+                            case '_':
+                                s.Append(replace[i]);
+                                break;
+                            default:
+                                s.Append(replace[i+1]); i++; break;
+                        }
+                    }
+                    else
+                    {
+                        s.Append(replace[i]);
+                    }
+                }
+
+                return s.ToString();
+            }
+
             return null;
         }
 

--- a/PrismaDB-QueryParser-MySQL/Visitors/CommonVisitors.cs
+++ b/PrismaDB-QueryParser-MySQL/Visitors/CommonVisitors.cs
@@ -5,9 +5,7 @@ using PrismaDB.QueryAST.DML;
 using PrismaDB.QueryParser.MySQL.AntlrGrammer;
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Text;
-using System.Diagnostics;
 
 namespace PrismaDB.QueryParser.MySQL
 {
@@ -80,58 +78,54 @@ namespace PrismaDB.QueryParser.MySQL
 
         public override object VisitStringLiteral([NotNull] MySqlParser.StringLiteralContext context)
         {
-
             var str = context.STRING_LITERAL().GetText();
 
             if (str.StartsWith("'"))
             {
-                str = str.Substring(1, str.Length - 2)
-                    .Replace("''", "'");
-
-                return new StringConstant(replace_common_sequences(str));
+                str = str.Substring(1, str.Length - 2).Replace("''", "'");
+                return new StringConstant(replaceCommonSequences(str));
             }
 
             if (str.StartsWith("\""))
             {
-                str = str.Substring(1, str.Length - 2)
-                    .Replace("\"\"", "\"");
-                return new StringConstant(replace_common_sequences(str));
+                str = str.Substring(1, str.Length - 2).Replace("\"\"", "\"");
+                return new StringConstant(replaceCommonSequences(str));
             }
 
-            string replace_common_sequences(string replace)
+            string replaceCommonSequences(string replace)
             {
-                var c = (char)26;
-                StringBuilder s = new StringBuilder();
-                for(int i = 0; i < replace.Length; i++)
+                var s = new StringBuilder();
+
+                for (int i = 0; i < replace.Length; i++)
                 {
-                    if(replace[i] == '\\' && (i <= replace.Length - 2))
+                    if (replace[i] == '\\' && (i <= replace.Length - 2))
                     {
-                        switch(replace[i+1])
+                        switch (replace[i + 1])
                         {
                             case '\\':
-                                s.Append("\\"); i++; break;
+                                s.Append('\\'); i++; break;
                             case 'b':
-                                s.Append("\b"); i++; break;
+                                s.Append('\b'); i++; break;
                             case 'n':
-                                s.Append("\n"); i++; break;
+                                s.Append('\n'); i++; break;
                             case 'r':
-                                s.Append("\r"); i++; break;
+                                s.Append('\r'); i++; break;
                             case 't':
-                                s.Append("\t"); i++;  break;
+                                s.Append('\t'); i++; break;
                             case '0':
-                                s.Append("\0"); i++; break;
+                                s.Append('\0'); i++; break;
                             case 'Z':
-                                s.Append(c); i++;  break;
+                                s.Append('\x1A'); i++; break;
                             case '"':
-                                s.Append("\""); i++; break;
+                                s.Append('"'); i++; break;
                             case '\'':
-                                s.Append("'"); i++;  break;
+                                s.Append('\''); i++; break;
                             case '%':
                             case '_':
                                 s.Append(replace[i]);
                                 break;
                             default:
-                                s.Append(replace[i+1]); i++; break;
+                                s.Append(replace[i + 1]); i++; break;
                         }
                     }
                     else

--- a/PrismaDB-QueryParser-MySQL/Visitors/CommonVisitors.cs
+++ b/PrismaDB-QueryParser-MySQL/Visitors/CommonVisitors.cs
@@ -78,14 +78,33 @@ namespace PrismaDB.QueryParser.MySQL
         public override object VisitStringLiteral([NotNull] MySqlParser.StringLiteralContext context)
         {
             var str = context.STRING_LITERAL().GetText();
+            var c = (char)26;
             if (str.StartsWith("'"))
             {
-                str = str.Substring(1, str.Length - 2).Replace("\\'", "'").Replace("''", "'");
+                str = str.Substring(1, str.Length - 2)
+                    .Replace("\\'", "'")
+                    .Replace("''", "'")
+                    .Replace("\\\\", "\\")
+                    .Replace("\\0", "\0")
+                    .Replace("\\b", "\b")
+                    .Replace("\\n", "\n")
+                    .Replace("\\r", "\r")
+                    .Replace("\\t", "\t")
+                    .Replace("\\Z", c.ToString());
                 return new StringConstant(str);
             }
             if (str.StartsWith("\""))
             {
-                str = str.Substring(1, str.Length - 2).Replace("\\\"", "\"").Replace("\"\"", "\"");
+                str = str.Substring(1, str.Length - 2)
+                    .Replace("\\\"", "\"")
+                    .Replace("\"\"", "\"")
+                    .Replace("\\\\","\\")
+                    .Replace("\\0", "\0")
+                    .Replace("\\b", "\b")
+                    .Replace("\\n", "\n")
+                    .Replace("\\r", "\r")
+                    .Replace("\\t", "\t")
+                    .Replace("\\Z", c.ToString());
                 return new StringConstant(str);
             }
             return null;


### PR DESCRIPTION
proper escaping of characters as per list in (https://dev.mysql.com/doc/refman/8.0/en/string-literals.html#character-escape-sequences) have been added. 

all characters except percentage(%) and underscore(_) are processed except for these 2 characters, which are noted to be automatically escaped outside of pattern matching contexts by the MySQL developer docs.